### PR TITLE
Added Dockerfile for a static binary of go-bitflow

### DIFF
--- a/static.Dockerfile
+++ b/static.Dockerfile
@@ -1,0 +1,12 @@
+# teambitflow/go-bitflow:static
+FROM golang:1.11-alpine as build
+ENV GO111MODULE=on
+RUN apk --no-cache add git gcc g++ musl-dev
+WORKDIR /build
+COPY . .
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /bitflow-pipeline ./cmd/bitflow-pipeline
+
+FROM scratch
+COPY --from=build /bitflow-pipeline /
+ENTRYPOINT ["/bitflow-pipeline"]
+


### PR DESCRIPTION
Figured out how to build entirely self-contained Go binary. Reduces Docker image size to 27MB and allows using go-bitflow in the bitflow4j Docker image.
Problem: Plugins cannot be compiled with the -static flag, so an image with go-bitflow and plugins still needs a working libc.